### PR TITLE
ci: add colcon tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,10 @@ jobs:
           set -euo pipefail
           source /opt/ros/humble/setup.bash
           colcon build --base-paths alpha_ws --merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release --event-handlers console_cohesion+
+      - name: Test
+        shell: bash
+        run: |
+          set -euo pipefail
+          source /opt/ros/humble/setup.bash
+          colcon test --base-paths alpha_ws --merge-install --event-handlers console_cohesion+ --event-handlers github_actions
+          colcon test-result --verbose


### PR DESCRIPTION
## Summary
- run `colcon test` in CI after build
- upload test summaries via event handlers

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `make agents-validate`


------
https://chatgpt.com/codex/tasks/task_e_68b2a7fa95b4832eb97f59c4c90fafdb