### PR TITLE
Use Apache-2.0 license for alpha_utils

### DIFF
--- a/alpha_ws/src/alpha_utils/package.xml
+++ b/alpha_ws/src/alpha_utils/package.xml
@@ -5,7 +5,7 @@
   <description>Common messages and services for the ALPHA rover stack.</description>
 
   <maintainer email="devnull@example.com">Alpha SW</maintainer>
-  <license>Proprietary</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>


### PR DESCRIPTION
## Summary
- switch alpha_utils package manifest to Apache-2.0 license

## Testing
- `pre-commit run --files alpha_ws/src/alpha_utils/package.xml` *(fails: command not found)*
- `colcon test --packages-select alpha_utils` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a7a05224832eb0792b3150a571f7