### PR TITLE
docs: log CI and calibration progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,13 +86,11 @@ jobs:
               python3-yaml || true
           fi
       - name: Show discovered packages
-        continue-on-error: true
         shell: bash
         run: |
           cd "$ALPHA_WS" || exit 0
           colcon list || true
       - name: Build (all packages)
-        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
@@ -102,10 +100,9 @@ jobs:
       - name: Validate configs (jsonschema)
         shell: bash
         run: |
-          cd alpha_rover
+          # Run config schema validation from repo root
           python3 scripts/validate_configs.py
       - name: Test (all packages)
-        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
@@ -116,5 +113,15 @@ jobs:
       - name: Run unit tests (pytest)
         shell: bash
         run: |
-          cd alpha_rover
-          python3 -m pytest alpha_ws/src/alpha_lidar_airy/test alpha_ws/src/alpha_comms/test alpha_ws/src/alpha_calibration_tools/test -q
+          set -euo pipefail
+          # Source ROS 2 and the built workspace so generated Python interfaces are importable
+          source /opt/ros/humble/setup.bash
+          if [ -f alpha_ws/install/setup.bash ]; then
+            source alpha_ws/install/setup.bash
+          fi
+          # Run package unit tests directly with pytest
+          python3 -m pytest \
+            alpha_ws/src/alpha_lidar_airy/test \
+            alpha_ws/src/alpha_comms/test \
+            alpha_ws/src/alpha_calibration_tools/test \
+            -q

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -79,3 +79,8 @@ Artifacts and decisions are linked from AGENTS docs where relevant.
 - Recorder:
   - Added `alpha_recorder/ring_recorder`: manages rotating rosbag2 ring (`--max-bag-duration`), trims to retention window, serves `/alpha/recorder/trigger` to gather pre-window segments and capture post-window into a new bag dir under `data/triggers/`.
   - Status on `/alpha/recorder/status`.
+
+## 2025-09-01
+- CI now builds/tests all packages and adds a `tf_ok` enforcement unit test (roadmap 10.6 — Calibration tools + TF preflight/CI).
+- Added `alpha_configs/extrinsics_current.yaml` for calibration (roadmap 7.13 — extrinsics_seed.yaml).
+- Integrated `video_controller` and wired into launch (roadmap 10.3 — Comms Manager + budgets + impairment harness in CI).


### PR DESCRIPTION
## Summary
- note CI builds/tests all packages and adds tf_ok unit test
- record extrinsics_current.yaml for calibration
- log video_controller integration and launch wiring

## Testing
- `make agents-validate`


------
https://chatgpt.com/codex/tasks/task_e_68b35df7a4ac832e91336446fd8caa0c