### PR TITLE
Bringup: NVBlox autostart wired to lidar_ready; diagnostics; agents-validate exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
           set -euo pipefail
           source /opt/ros/humble/setup.bash
           cd "$ALPHA_WS"
+          if [ -f install/setup.bash ]; then
+            source install/setup.bash
+          fi
           colcon test --merge-install
           colcon test-result --verbose
       - name: Run unit tests (pytest)

--- a/.github/workflows/sensors.yml
+++ b/.github/workflows/sensors.yml
@@ -12,12 +12,26 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Setup ROS 2 apt sources
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: humble
       - name: Install ROS 2 tooling
         run: |
           sudo apt-get update
           sudo apt-get install -y python3-vcstool python3-colcon-common-extensions python3-rosdep
           sudo rosdep init || true
           rosdep update
+      - name: Install core ROS deps for LiDAR build (smoke)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake \
+            libyaml-cpp-dev \
+            ros-humble-rclcpp \
+            ros-humble-sensor-msgs \
+            ros-humble-std-msgs \
+            ros-humble-diagnostic-msgs
       - name: Import third-party sources
         run: |
           mkdir -p alpha_ws/third_party/src
@@ -39,5 +53,5 @@ jobs:
         run: |
           set -e
           cd alpha_ws
-          colcon build --event-handlers console_cohesion+ --packages-select \
+          colcon build --event-handlers console_cohesion+ --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select \
             alpha_lidar_airy_cpp alpha_lidar_airy alpha_bringup alpha_testing || true

--- a/alpha_ws/src/alpha_bringup/alpha_bringup/mapping_autostart.py
+++ b/alpha_ws/src/alpha_bringup/alpha_bringup/mapping_autostart.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+import subprocess
+from typing import Optional
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy
+from rclpy.clock import Clock, ClockType
+from std_msgs.msg import Bool
+
+
+class MappingAutostart(Node):
+    def __init__(self):
+        super().__init__('mapping_autostart')
+        # Params
+        self.declare_parameter('allow_single_lidar', False)
+        self.declare_parameter('degrade_timeout_s', 30)
+        self.declare_parameter('compose_file', 'deploy/compose.mapping.yaml')
+        self.declare_parameter('env_file', 'deploy/IMAGES.lock')
+
+        # Gate subscription (durable)
+        qos = QoSProfile(depth=1)
+        qos.reliability = ReliabilityPolicy.RELIABLE
+        qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
+        self.sub = self.create_subscription(Bool, '/alpha/gates/lidar_ready', self._on_gate, qos)
+
+        self._steady = Clock(clock_type=ClockType.STEADY_TIME)
+        self._gate_true = False
+        self._last_false_ns: Optional[int] = None
+        self._timer = self.create_timer(0.5, self._tick)
+        self.get_logger().info('mapping_autostart active: strict gate; degrade behind param')
+
+    def _on_gate(self, msg: Bool):
+        now = self._steady.now().nanoseconds
+        if msg.data:
+            self._gate_true = True
+            self._last_false_ns = None
+        else:
+            self._gate_true = False
+            if self._last_false_ns is None:
+                self._last_false_ns = now
+
+    def _tick(self):
+        allow_single = self.get_parameter('allow_single_lidar').get_parameter_value().bool_value
+        timeout_s = int(self.get_parameter('degrade_timeout_s').get_parameter_value().integer_value)
+        now = self._steady.now().nanoseconds
+
+        if self._gate_true:
+            # Ensure mapping is up
+            self._compose(['up', '-d'])
+            return
+
+        # Gate false
+        if self._mapping_running():
+            # Stop after 3s of persistent false to avoid flapping
+            if self._last_false_ns and (now - self._last_false_ns) / 1e9 > 3.0:
+                self.get_logger().warn('lidar_ready fell false; stopping mapping')
+                self._compose(['stop'])
+            return
+
+        # Consider degrade fallback
+        if allow_single and self._last_false_ns and (now - self._last_false_ns) / 1e9 > timeout_s:
+            self.get_logger().warn('lidar_ready timeout; starting NVBlox in DEGRADE mode')
+            self._compose(['up', '-d'])
+
+    def _compose(self, args):
+        compose = self.get_parameter('compose_file').get_parameter_value().string_value
+        envf = self.get_parameter('env_file').get_parameter_value().string_value
+        cmd = ['docker', 'compose', '-f', compose, '--env-file', envf] + args
+        try:
+            subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+        except Exception as e:
+            self.get_logger().error(f'docker compose failed: {e}')
+
+    def _mapping_running(self) -> bool:
+        compose = self.get_parameter('compose_file').get_parameter_value().string_value
+        envf = self.get_parameter('env_file').get_parameter_value().string_value
+        try:
+            out = subprocess.check_output(['docker', 'compose', '-f', compose, '--env-file', envf, 'ps', '--status', 'running'], text=True)
+            return 'mapping' in out
+        except Exception:
+            return False
+
+
+def main():
+    rclpy.init()
+    node = MappingAutostart()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+

--- a/alpha_ws/src/alpha_bringup/launch/startup.launch.py
+++ b/alpha_ws/src/alpha_bringup/launch/startup.launch.py
@@ -227,4 +227,19 @@ def generate_launch_description():
             }],
             output='screen',
         ),
+
+
+        # Mapping autostart wired to durable lidar_ready gate
+        Node(
+            package='alpha_bringup',
+            executable='mapping_autostart',
+            name='alpha_mapping_autostart',
+            parameters=[{
+                'allow_single_lidar': False,
+                'degrade_timeout_s': 30,
+                'compose_file': 'deploy/compose.mapping.yaml',
+                'env_file': 'deploy/IMAGES.lock',
+            }],
+            output='screen',
+        ),
 ])

--- a/alpha_ws/src/alpha_bringup/setup.py
+++ b/alpha_ws/src/alpha_bringup/setup.py
@@ -24,6 +24,7 @@ setup(
             'config_manager = alpha_bringup.config_manager:main',
             'startup_sequencer = alpha_bringup.startup_sequencer:main',
             'lidar_ready_gate = alpha_bringup.lidar_ready_gate:main',
+            'mapping_autostart = alpha_bringup.mapping_autostart:main',
         ],
     },
 )

--- a/alpha_ws/src/alpha_oak/AGENTS.md
+++ b/alpha_ws/src/alpha_oak/AGENTS.md
@@ -49,6 +49,7 @@ tests:
 notes: >
   Uses apt-installed depthai_ros_driver. Switch to source/pinned SHA only if features/fixes require.
 
+---
 # AGENT — alpha_oak
 
 ## Interfaces
@@ -56,4 +57,3 @@ notes: >
 
 ## Runbooks
 See start/stop/healthcheck above.
-

--- a/alpha_ws/src/alpha_testing/AGENTS.md
+++ b/alpha_ws/src/alpha_testing/AGENTS.md
@@ -41,8 +41,8 @@ tests:
 notes: >
   Runtime acceptance checks, run on-device against live topics.
 
+---
 # AGENT — alpha_testing
 
 ## LiDAR Acceptance
 Passes when both front and rear LiDAR publish 96×900 PointCloud2 with header skew ≤ 20 ms.
-

--- a/alpha_ws/src/alpha_vslam/AGENTS.md
+++ b/alpha_ws/src/alpha_vslam/AGENTS.md
@@ -43,7 +43,7 @@ tests:
 notes: >
   Runs Isaac ROS Visual SLAM inside a container with pinned image digest.
 
+---
 # AGENT — alpha_vslam
 
 Wrapper that launches Visual SLAM in a container and remaps inputs to canonical camera topics. Adjust launch parameters and remappings for stereo as needed.
-

--- a/docs/AGENTS_INDEX.md
+++ b/docs/AGENTS_INDEX.md
@@ -4,18 +4,16 @@ _Generated: 2025-08-31_
 
 | Agent | Type | Status | Version | Updated | Owner | Path |
 |---|---|---|---|---|---|---|
-| Archive/2025-08/_ros2_ws_backup_20250825-132949/AGENTS.md | ? | ? | ? | ? | ? | [Archive/2025-08/_ros2_ws_backup_20250825-132949/AGENTS.md](Archive/2025-08/_ros2_ws_backup_20250825-132949/AGENTS.md) |
-| alpha_rover/alpha_ws/src/alpha_oak/AGENTS.md | ? | ? | ? | ? | ? | [alpha_rover/alpha_ws/src/alpha_oak/AGENTS.md](alpha_rover/alpha_ws/src/alpha_oak/AGENTS.md) |
-| alpha_rover/alpha_ws/src/alpha_testing/AGENTS.md | ? | ? | ? | ? | ? | [alpha_rover/alpha_ws/src/alpha_testing/AGENTS.md](alpha_rover/alpha_ws/src/alpha_testing/AGENTS.md) |
-| alpha_rover/alpha_ws/src/alpha_vslam/AGENTS.md | ? | ? | ? | ? | ? | [alpha_rover/alpha_ws/src/alpha_vslam/AGENTS.md](alpha_rover/alpha_ws/src/alpha_vslam/AGENTS.md) |
-| alpha_rover_legacy/AGENTS.md | ? | ? | ? | ? | ? | [alpha_rover_legacy/AGENTS.md](alpha_rover_legacy/AGENTS.md) |
-| alpha_configs | config | alpha | v2.3 | 2025-08-30 | Alpha SW | [alpha_rover/alpha_configs/AGENTS.md](alpha_rover/alpha_configs/AGENTS.md) |
-| alpha_project_root | docs | alpha | v2.3 | 2025-08-30 | Tim | [alpha_rover/AGENTS.md](alpha_rover/AGENTS.md) |
-| alpha_project_root | docs | alpha | v2.3 | 2025-08-30 | Tim | [alpha_rover/examples/AGENTS.md](alpha_rover/examples/AGENTS.md) |
-| alpha_bringup | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_rover/alpha_ws/src/alpha_bringup/AGENTS.md](alpha_rover/alpha_ws/src/alpha_bringup/AGENTS.md) |
-| alpha_lidar_airy | ros2_package | draft | v0.2 | 2025-08-31 | Alpha SW | [alpha_rover/alpha_ws/src/alpha_lidar_airy/AGENTS.md](alpha_rover/alpha_ws/src/alpha_lidar_airy/AGENTS.md) |
-| alpha_lidar_airy_cpp | ros2_package | beta | v0.1 | 2025-08-31 | Alpha SW | [alpha_rover/alpha_ws/src/alpha_lidar_airy_cpp/AGENTS.md](alpha_rover/alpha_ws/src/alpha_lidar_airy_cpp/AGENTS.md) |
-| alpha_mapping | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_rover/alpha_ws/src/alpha_mapping/AGENTS.md](alpha_rover/alpha_ws/src/alpha_mapping/AGENTS.md) |
-| alpha_mode_manager | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_rover/alpha_ws/src/alpha_mode_manager/AGENTS.md](alpha_rover/alpha_ws/src/alpha_mode_manager/AGENTS.md) |
-| alpha_observability | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_rover/alpha_ws/src/alpha_observability/AGENTS.md](alpha_rover/alpha_ws/src/alpha_observability/AGENTS.md) |
-| alpha_orchestrator | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_rover/alpha_ws/src/alpha_orchestrator/AGENTS.md](alpha_rover/alpha_ws/src/alpha_orchestrator/AGENTS.md) |
+| alpha_ws/src/alpha_oak/AGENTS.md | ? | ? | ? | ? | ? | [alpha_ws/src/alpha_oak/AGENTS.md](alpha_ws/src/alpha_oak/AGENTS.md) |
+| alpha_ws/src/alpha_testing/AGENTS.md | ? | ? | ? | ? | ? | [alpha_ws/src/alpha_testing/AGENTS.md](alpha_ws/src/alpha_testing/AGENTS.md) |
+| alpha_ws/src/alpha_vslam/AGENTS.md | ? | ? | ? | ? | ? | [alpha_ws/src/alpha_vslam/AGENTS.md](alpha_ws/src/alpha_vslam/AGENTS.md) |
+| alpha_configs | config | alpha | v2.3 | 2025-08-30 | Alpha SW | [alpha_configs/AGENTS.md](alpha_configs/AGENTS.md) |
+| alpha_project_root | docs | alpha | v2.3 | 2025-08-30 | Tim | [AGENTS.md](AGENTS.md) |
+| alpha_project_root | docs | alpha | v2.3 | 2025-08-30 | Tim | [examples/AGENTS.md](examples/AGENTS.md) |
+| alpha_bringup | ros2_package | draft | v0.2 | 2025-08-31 | Alpha SW | [alpha_ws/src/alpha_bringup/AGENTS.md](alpha_ws/src/alpha_bringup/AGENTS.md) |
+| alpha_lidar_airy | ros2_package | draft | v0.2 | 2025-08-31 | Alpha SW | [alpha_ws/src/alpha_lidar_airy/AGENTS.md](alpha_ws/src/alpha_lidar_airy/AGENTS.md) |
+| alpha_lidar_airy_cpp | ros2_package | beta | v0.1 | 2025-08-31 | Alpha SW | [alpha_ws/src/alpha_lidar_airy_cpp/AGENTS.md](alpha_ws/src/alpha_lidar_airy_cpp/AGENTS.md) |
+| alpha_mapping | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_mapping/AGENTS.md](alpha_ws/src/alpha_mapping/AGENTS.md) |
+| alpha_mode_manager | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_mode_manager/AGENTS.md](alpha_ws/src/alpha_mode_manager/AGENTS.md) |
+| alpha_observability | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_observability/AGENTS.md](alpha_ws/src/alpha_observability/AGENTS.md) |
+| alpha_orchestrator | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_orchestrator/AGENTS.md](alpha_ws/src/alpha_orchestrator/AGENTS.md) |

--- a/scripts/agents_validate.py
+++ b/scripts/agents_validate.py
@@ -119,6 +119,12 @@ def validate_front(front, path):
     errs.append("links.roadmap is required")
   return errs
 
+EXCLUDE_PREFIXES = ("Archive/", "alpha_rover_legacy/", "Archive\\", "alpha_rover_legacy\\")
+
+def _is_excluded(path: str) -> bool:
+  p = path.replace("\\", "/")
+  return any(p.startswith(pref) for pref in EXCLUDE_PREFIXES)
+
 def main():
   base = sys.argv[1] if len(sys.argv) > 1 else "."
   failed = False
@@ -126,8 +132,10 @@ def main():
   for dirpath, _, filenames in os.walk(base):
     for fn in filenames:
       if fn == "AGENTS.md":
-        found += 1
         p = os.path.join(dirpath, fn)
+        if _is_excluded(os.path.relpath(p, base)):
+          continue
+        found += 1
         with open(p, "r", encoding="utf-8") as f:
           txt = f.read()
         fm_txt, body = parse_front_matter(txt)
@@ -145,7 +153,7 @@ def main():
         else:
           print(f"[OK] {p}")
   if found == 0:
-    print("[WARN] no AGENTS.md files found under", base)
+    print("[WARN] no AGENTS.md files found under", base, "(after exclusions)")
   sys.exit(1 if failed else 0)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to PR #6. Adds mapping_autostart (strict gate + optional degrade), publishes gate diagnostics, excludes Archive/legacy from agents validator, and resolves conflicts vs trunk.\n\nHow to validate:\n- ros2 launch alpha_bringup startup.launch.py\n- watch /alpha/gates/lidar_ready and /alpha/gates/lidar_ready_status\n- verify mapping starts only when gate is true.\n