### PR TITLE
LiDAR: support optional airy_http config (disabled by default)

### DIFF
--- a/alpha_configs/lidar_airy.yaml
+++ b/alpha_configs/lidar_airy.yaml
@@ -21,3 +21,29 @@ http:
       body: '{"mode": 0}'
       headers: { Content-Type: application/json }
   timeout_sec: 1.0
+
+# Optional, config-driven HTTP control block (disabled by default)
+# When enabled, mode_service builds requests from this section and does a
+# light verification via setting_data.json if verify_after_set:=true.
+airy_http:
+  enabled: false
+  endpoints:
+    front:
+      base_url: "http://192.168.1.200"
+      mode_path: "/api/mode"
+      # method: POST
+      # headers: { Content-Type: application/json }
+      # payload_run: '{"mode":"RUN"}'
+      # payload_standby: '{"mode":"STANDBY"}'
+    rear:
+      base_url: "http://192.168.1.201"
+      mode_path: "/api/mode"
+      # method: POST
+      # headers: { Content-Type: application/json }
+      # payload_run: '{"mode":"RUN"}'
+      # payload_standby: '{"mode":"STANDBY"}'
+  timeouts_ms:
+    connect: 400
+    read: 400
+  retries: 2
+  backoff_ms: 150

--- a/alpha_configs/schemas/lidar_airy.schema.json
+++ b/alpha_configs/schemas/lidar_airy.schema.json
@@ -49,6 +49,57 @@
       },
       "required": ["endpoints"],
       "additionalProperties": true
+    },
+    "airy_http": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "endpoints": {
+          "type": "object",
+          "properties": {
+            "front": {
+              "type": "object",
+              "properties": {
+                "base_url": { "type": "string", "minLength": 1 },
+                "mode_path": { "type": "string", "minLength": 1 },
+                "method": { "type": "string" },
+                "headers": { "type": "object", "additionalProperties": { "type": "string" } },
+                "payload_run": { "type": "string" },
+                "payload_standby": { "type": "string" }
+              },
+              "required": ["base_url", "mode_path"],
+              "additionalProperties": true
+            },
+            "rear": {
+              "type": "object",
+              "properties": {
+                "base_url": { "type": "string", "minLength": 1 },
+                "mode_path": { "type": "string", "minLength": 1 },
+                "method": { "type": "string" },
+                "headers": { "type": "object", "additionalProperties": { "type": "string" } },
+                "payload_run": { "type": "string" },
+                "payload_standby": { "type": "string" }
+              },
+              "required": ["base_url", "mode_path"],
+              "additionalProperties": true
+            }
+          },
+          "required": ["front", "rear"],
+          "additionalProperties": false
+        },
+        "timeouts_ms": {
+          "type": "object",
+          "properties": {
+            "connect": { "type": "integer", "minimum": 1 },
+            "read": { "type": "integer", "minimum": 1 }
+          },
+          "additionalProperties": false
+        },
+        "retries": { "type": "integer", "minimum": 0 },
+        "backoff_ms": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["enabled", "endpoints"],
+      "additionalProperties": true
     }
   },
   "required": [
@@ -72,4 +123,3 @@
     }
   }
 }
-

--- a/alpha_ws/src/alpha_lidar_airy/alpha_lidar_airy/mode_service_node.py
+++ b/alpha_ws/src/alpha_lidar_airy/alpha_lidar_airy/mode_service_node.py
@@ -54,10 +54,17 @@ class AiryModeService(Node):
             self._http_cfg = _load_yaml(endpoints_param)
         else:
             try:
-                http_cfg = _load_yaml('alpha_configs/lidar_airy.yaml').get('http', {})
+                lidar_cfg = _load_yaml('alpha_configs/lidar_airy.yaml')
+                http_cfg = lidar_cfg.get('http', {})
             except Exception:
                 http_cfg = {}
             self._http_cfg = http_cfg
+
+        # Optional airy_http block (config-driven; device-specific endpoints)
+        try:
+            self._airy_http = lidar_cfg.get('airy_http', {}) if isinstance(lidar_cfg, dict) else {}
+        except Exception:
+            self._airy_http = {}
 
         qos = QoSProfile(
             depth=10,
@@ -85,19 +92,48 @@ class AiryModeService(Node):
         ep = (self._http_cfg or {}).get('endpoints', {})
         return ep.get('run' if mode == 1 else 'standby')
 
-    def _http_call(self, ip: str, endpoint: Dict) -> Tuple[bool, str]:
+    def _endpoint_airy(self, which: str, mode: int) -> Optional[Dict]:
+        cfg = self._airy_http or {}
+        if not cfg or not bool(cfg.get('enabled', False)):
+            return None
+        eps = cfg.get('endpoints', {}) or {}
+        dev = eps.get(which, {}) or {}
+        base = dev.get('base_url') or ''
+        path = dev.get('mode_path') or ''
+        if not base or not path:
+            return None
+        method = (dev.get('method') or 'POST').upper()
+        headers = dev.get('headers') or {'Content-Type': 'application/json'}
+        # payload overrides per device
+        if mode == 1:
+            body = dev.get('payload_run') or '{"mode":"RUN"}'
+        else:
+            body = dev.get('payload_standby') or '{"mode":"STANDBY"}'
+        url = base.rstrip('/') + path
+        return {'method': method, 'path': url, 'body': body, 'headers': headers}
+
+    def _http_call(self, ip: str, endpoint: Dict, *, absolute_url: bool = False, use_airy_timeouts: bool = False) -> Tuple[bool, str]:
         method = (endpoint.get('method') or 'POST').upper()
         path = endpoint.get('path') or '/'
         body = endpoint.get('body')
         headers = endpoint.get('headers') or {}
-        url = f'http://{ip}{path}'
+        url = path if absolute_url else f'http://{ip}{path}'
         data = body.encode('utf-8') if isinstance(body, str) else None
         req = urllib.request.Request(url=url, data=data, method=method)
         for k, v in headers.items():
             req.add_header(k, v)
-        timeout = float(self.get_parameter('http_timeout_sec').get_parameter_value().double_value)
-        retries = int(self.get_parameter('http_retries').get_parameter_value().integer_value)
-        backoff_ms = int(self.get_parameter('http_backoff_ms').get_parameter_value().integer_value)
+        # timeouts/retries from params; airy_http can override when enabled
+        if use_airy_timeouts and isinstance(self._airy_http, dict):
+            tcfg = self._airy_http.get('timeouts_ms', {}) or {}
+            t_conn = float(tcfg.get('connect', 0) or 0) / 1000.0
+            t_read = float(tcfg.get('read', 0) or 0) / 1000.0
+            timeout = max(t_conn, t_read, float(self.get_parameter('http_timeout_sec').get_parameter_value().double_value))
+            retries = int(self._airy_http.get('retries', self.get_parameter('http_retries').get_parameter_value().integer_value) or 0)
+            backoff_ms = int(self._airy_http.get('backoff_ms', self.get_parameter('http_backoff_ms').get_parameter_value().integer_value) or 0)
+        else:
+            timeout = float(self.get_parameter('http_timeout_sec').get_parameter_value().double_value)
+            retries = int(self.get_parameter('http_retries').get_parameter_value().integer_value)
+            backoff_ms = int(self.get_parameter('http_backoff_ms').get_parameter_value().integer_value)
         attempts = 1 + max(0, retries)
         last_err: str = ''
         for i in range(attempts):
@@ -209,9 +245,10 @@ class AiryModeService(Node):
             return True, 'dry-run'
 
         # Attempt configured endpoint first (if provided)
-        endpoint = self._endpoint(mode)
-        if endpoint:
-            ok, msg = self._http_call(ip, endpoint)
+        # Prefer airy_http if enabled; else fall back to legacy http.endpoints
+        ep_abs = self._endpoint_airy(which, mode)
+        if ep_abs:
+            ok, msg = self._http_call(ip, ep_abs, absolute_url=True, use_airy_timeouts=True)
             if ok:
                 # Optional verification step to guard silent no-ops
                 verify = bool(self.get_parameter('verify_after_set').get_parameter_value().bool_value)
@@ -228,6 +265,22 @@ class AiryModeService(Node):
                     self._states[which] = (mode, mode == 1)
                     return ok, msg
             # Fall through to legacy if endpoint failed
+        endpoint = self._endpoint(mode)
+        if endpoint:
+            ok, msg = self._http_call(ip, endpoint)
+            if ok:
+                verify = bool(self.get_parameter('verify_after_set').get_parameter_value().bool_value)
+                if verify:
+                    timeout = float(self.get_parameter('http_timeout_sec').get_parameter_value().double_value)
+                    v_ok, v_msg = self._verify_mode(ip, mode, timeout)
+                    if v_ok:
+                        self._states[which] = (mode, mode == 1)
+                        return True, f'{msg}; {v_msg}'
+                    else:
+                        self.get_logger().warn(f'Configured endpoint ok but verification failed: {v_msg}; attempting legacy fallback')
+                else:
+                    self._states[which] = (mode, mode == 1)
+                    return ok, msg
 
         # Legacy firmware fallback
         ok, msg = self._apply_mode_via_legacy_form(ip, mode)

--- a/docs/INTEGRATION_SENSORS.md
+++ b/docs/INTEGRATION_SENSORS.md
@@ -49,6 +49,30 @@ Pin exact SHAs after hardware validation.
 Runbooks exist in `alpha_ws/src/alpha_lidar_airy/AGENTS.md` and `alpha_ws/src/alpha_bringup/launch/startup.launch.py`.
 Default backend is `cpp`; switch with `backend:=numpy` if needed.
 
+Optional HTTP control (mode service):
+- The mode service can toggle AIRY Run/Standby via HTTP. It supports two config paths:
+  - Legacy `http.endpoints.{run,standby}` in `alpha_configs/lidar_airy.yaml` (path/method/body/headers).
+  - Optional `airy_http` block (disabled by default) with per-device base URLs and payloads.
+- You can enable verification and adjust retries via node params:
+  - `verify_after_set` (bool, default false): after HTTP set, GET `setting_data.json` to verify `OpM`.
+  - `http_retries` (int, default 0) and `http_backoff_ms` (int, default 150).
+- The node always falls back to the legacy UI form flow (Parameter_Setting.html) if configured endpoints fail.
+
+Example run (dry-run by default unless you set `http_enabled:=true`):
+```
+ros2 run alpha_lidar_airy mode_service_node \
+  --ros-args \
+  -p network_config:=alpha_configs/network.yaml \
+  -p http_enabled:=true \
+  -p verify_after_set:=true \
+  -p http_retries:=1 \
+  -p http_backoff_ms:=200
+
+# Standby then Run
+ros2 service call /alpha/ui/cmd/lidar_mode alpha_utils/srv/SetLidarMode "{target: 'both', op_mode: 0}"
+ros2 service call /alpha/ui/cmd/lidar_mode alpha_utils/srv/SetLidarMode "{target: 'both', op_mode: 1}"
+```
+
 ---
 
 ## LiDAR acceptance test (runtime)


### PR DESCRIPTION
- Adds airy_http config block to lidar_airy.yaml (disabled by default).\n- Schema updated to validate endpoints/timeouts/retry fields.\n- mode_service: prefers airy_http when enabled; otherwise uses existing http.endpoints then legacy UI fallback.\n- Optional verify-after-set remains available.\n\nBackwards-compatible; no behavior change unless airy_http.enabled=true.