### PR TITLE
Docs: regenerate AGENTS_INDEX.md (deterministic)

### DIFF
--- a/docs/AGENTS_INDEX.md
+++ b/docs/AGENTS_INDEX.md
@@ -2,9 +2,6 @@
 
 | Agent | Type | Status | Version | Updated | Owner | Path |
 |---|---|---|---|---|---|---|
-| alpha_ws/src/alpha_oak/AGENTS.md | ? | ? | ? | ? | ? | [alpha_ws/src/alpha_oak/AGENTS.md](alpha_ws/src/alpha_oak/AGENTS.md) |
-| alpha_ws/src/alpha_testing/AGENTS.md | ? | ? | ? | ? | ? | [alpha_ws/src/alpha_testing/AGENTS.md](alpha_ws/src/alpha_testing/AGENTS.md) |
-| alpha_ws/src/alpha_vslam/AGENTS.md | ? | ? | ? | ? | ? | [alpha_ws/src/alpha_vslam/AGENTS.md](alpha_ws/src/alpha_vslam/AGENTS.md) |
 | alpha_configs | config | alpha | v2.3 | 2025-08-30 | Alpha SW | [alpha_configs/AGENTS.md](alpha_configs/AGENTS.md) |
 | alpha_project_root | docs | alpha | v2.3 | 2025-08-30 | Tim | [AGENTS.md](AGENTS.md) |
 | alpha_project_root | docs | alpha | v2.3 | 2025-08-30 | Tim | [examples/AGENTS.md](examples/AGENTS.md) |
@@ -18,5 +15,3 @@
 | alpha_orchestrator | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_orchestrator/AGENTS.md](alpha_ws/src/alpha_orchestrator/AGENTS.md) |
 | alpha_testing | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_testing/AGENTS.md](alpha_ws/src/alpha_testing/AGENTS.md) |
 | alpha_vslam | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_vslam/AGENTS.md](alpha_ws/src/alpha_vslam/AGENTS.md) |
-| alpha_observability | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_observability/AGENTS.md](alpha_ws/src/alpha_observability/AGENTS.md) |
-| alpha_orchestrator | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_orchestrator/AGENTS.md](alpha_ws/src/alpha_orchestrator/AGENTS.md) |


### PR DESCRIPTION
Pre-commit hook rewrote docs/AGENTS_INDEX.md; committing deterministic index to unblock Docs Validation job.