### PR TITLE
CI(Sensors): fix arg-order enforcement (packages-first)

### DIFF
--- a/.github/workflows/sensors.yml
+++ b/.github/workflows/sensors.yml
@@ -14,10 +14,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Enforce colcon arg order policy
         run: |
+          # Check only actual colcon build lines, not enforcement lines
           # Must have packages-select before cmake-args
-          grep -nE 'colcon build .*--packages-select .* --cmake-args' .github/workflows/sensors.yml
-          # Must NOT have cmake-args before packages-select
-          if grep -nE 'colcon build .*--cmake-args .* --packages-select' .github/workflows/sensors.yml; then
+          if ! grep -nE '^[[:space:]]*colcon build .*--packages-select .* --cmake-args' .github/workflows/sensors.yml; then
+            echo "::error ::Missing packages-first colcon form in sensors.yml"; exit 1;
+          fi
+          # Must NOT have cmake-args before packages-select on any colcon line
+          if grep -nE '^[[:space:]]*colcon build .*--cmake-args .* --packages-select' .github/workflows/sensors.yml; then
             echo "::error ::Use packages-first colcon form in sensors.yml"; exit 1;
           fi
       - name: Setup ROS 2 apt sources

--- a/docs/AGENTS_INDEX.md
+++ b/docs/AGENTS_INDEX.md
@@ -2,9 +2,6 @@
 
 | Agent | Type | Status | Version | Updated | Owner | Path |
 |---|---|---|---|---|---|---|
-| alpha_ws/src/alpha_oak/AGENTS.md | ? | ? | ? | ? | ? | [alpha_ws/src/alpha_oak/AGENTS.md](alpha_ws/src/alpha_oak/AGENTS.md) |
-| alpha_ws/src/alpha_testing/AGENTS.md | ? | ? | ? | ? | ? | [alpha_ws/src/alpha_testing/AGENTS.md](alpha_ws/src/alpha_testing/AGENTS.md) |
-| alpha_ws/src/alpha_vslam/AGENTS.md | ? | ? | ? | ? | ? | [alpha_ws/src/alpha_vslam/AGENTS.md](alpha_ws/src/alpha_vslam/AGENTS.md) |
 | alpha_configs | config | alpha | v2.3 | 2025-08-30 | Alpha SW | [alpha_configs/AGENTS.md](alpha_configs/AGENTS.md) |
 | alpha_project_root | docs | alpha | v2.3 | 2025-08-30 | Tim | [AGENTS.md](AGENTS.md) |
 | alpha_project_root | docs | alpha | v2.3 | 2025-08-30 | Tim | [examples/AGENTS.md](examples/AGENTS.md) |
@@ -18,5 +15,3 @@
 | alpha_orchestrator | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_orchestrator/AGENTS.md](alpha_ws/src/alpha_orchestrator/AGENTS.md) |
 | alpha_testing | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_testing/AGENTS.md](alpha_ws/src/alpha_testing/AGENTS.md) |
 | alpha_vslam | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_vslam/AGENTS.md](alpha_ws/src/alpha_vslam/AGENTS.md) |
-| alpha_observability | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_observability/AGENTS.md](alpha_ws/src/alpha_observability/AGENTS.md) |
-| alpha_orchestrator | ros2_package | draft | v0.1 | 2025-08-30 | Alpha SW | [alpha_ws/src/alpha_orchestrator/AGENTS.md](alpha_ws/src/alpha_orchestrator/AGENTS.md) |


### PR DESCRIPTION
Replace naive grep with anchored patterns so enforcement doesn't match itself. Ensures we only flag real colcon commands.\n\nCurrent failures are false positives due to matching the enforcement lines in sensors.yml.