### PR TITLE
CI: install core ROS deps (pluginlib, rclpy/rclcpp, msgs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             ros-humble-ros-base \
+            ros-humble-pluginlib \
+            ros-humble-rclpy \
+            ros-humble-rclcpp \
+            ros-humble-std-msgs \
+            ros-humble-sensor-msgs \
             python3-colcon-common-extensions \
             python3-colcon-ros \
             ros-dev-tools \


### PR DESCRIPTION
Adds key ROS packages to base install to avoid build gaps when rosdep hiccups: pluginlib, rclpy/rclcpp, std/sensor msgs. Rosdep remains primary; this is a safety net for CI stability.