### PR TITLE
alpha_mapping: shared_ptr provider; fix pluginlib instance creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             ros-humble-ros-base \
+            ros-humble-pluginlib \
+            ros-humble-rclpy \
+            ros-humble-rclcpp \
+            ros-humble-std-msgs \
+            ros-humble-sensor-msgs \
             python3-colcon-common-extensions \
             python3-colcon-ros \
             ros-dev-tools \

--- a/alpha_ws/src/alpha_mapping/CMakeLists.txt
+++ b/alpha_ws/src/alpha_mapping/CMakeLists.txt
@@ -11,7 +11,13 @@ add_executable(nvblox src/nvblox_dummy_node.cpp)
 ament_target_dependencies(nvblox rclcpp sensor_msgs)
 
 add_executable(mapping_node src/mapping_node.cpp)
-ament_target_dependencies(mapping_node rclcpp sensor_msgs alpha_utils)
+ament_target_dependencies(mapping_node rclcpp sensor_msgs alpha_utils pluginlib)
+# Ensure local public headers are visible to dependents and this target
+target_include_directories(mapping_node
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
 
 install(TARGETS nvblox
   DESTINATION lib/${PROJECT_NAME}
@@ -23,6 +29,11 @@ install(TARGETS mapping_node
 
 add_library(nvblox_provider SHARED src/nvblox_provider.cpp)
 ament_target_dependencies(nvblox_provider rclcpp sensor_msgs pluginlib)
+target_include_directories(nvblox_provider
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
 
 pluginlib_export_plugin_description_file(alpha_mapping plugin_description.xml)
 

--- a/alpha_ws/src/alpha_mapping/src/mapping_node.cpp
+++ b/alpha_ws/src/alpha_mapping/src/mapping_node.cpp
@@ -133,12 +133,12 @@ public:
     std::string plugin_name = this->get_parameter("provider_plugin").as_string();
     try {
       loader_ = std::make_shared<pluginlib::ClassLoader<IMappingProvider>>("alpha_mapping", "alpha_mapping::IMappingProvider");
-      provider_.reset(loader_->createSharedInstance(plugin_name));
+      provider_ = loader_->createSharedInstance(plugin_name);
       provider_->configure(this);
       RCLCPP_INFO(this->get_logger(), "Loaded provider plugin: %s", plugin_name.c_str());
     } catch (const std::exception &e) {
       RCLCPP_WARN(this->get_logger(), "Failed to load provider plugin '%s': %s. Using DummyProvider.", plugin_name.c_str(), e.what());
-      provider_.reset(new DummyProvider());
+      provider_ = std::make_shared<DummyProvider>();
       provider_->configure(this);
     }
 
@@ -178,7 +178,7 @@ public:
   }
 
 private:
-  std::unique_ptr<IMappingProvider> provider_;
+  std::shared_ptr<IMappingProvider> provider_;
   std::vector<rclcpp::Subscription<PointCloud2>::SharedPtr> subs_;
   std::shared_ptr<pluginlib::ClassLoader<IMappingProvider>> loader_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr status_pub_;


### PR DESCRIPTION
- Switch provider_ to std::shared_ptr<IMappingProvider>.\n- Use loader_->createSharedInstance(plugin_name) to get a shared pointer.\n- Avoid passing shared_ptr to unique_ptr::reset which caused build error.\n\nFixes remaining alpha_mapping build failure in CI.