### PR TITLE
CI: split core vs mapping (non-gating); add nightly mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [ trunk ]
   pull_request:
     branches: [ trunk, main, '**' ]
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   changes:
@@ -12,6 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      mapping: ${{ steps.filter.outputs.mapping }}
     steps:
       - uses: actions/checkout@v4
       - id: filter
@@ -26,6 +34,9 @@ jobs:
               - 'deploy/**'
               - '.github/workflows/ci.yml'
               - '!**/*.md'
+            mapping:
+              - 'alpha_ws/src/alpha_mapping/**'
+              - 'alpha_ws/src/**/alpha_mapping*'
 
   docs:
     name: Docs Validation
@@ -119,7 +130,7 @@ jobs:
         run: |
           cd "$ALPHA_WS" || exit 0
           colcon list || true
-      - name: Build (all packages)
+      - name: Build (core packages; skip alpha_mapping)
         shell: bash
         run: |
           set -euo pipefail
@@ -128,13 +139,15 @@ jobs:
           source /opt/ros/humble/setup.bash
           set -u
           cd "$ALPHA_WS"
-          colcon build --merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+          colcon build --merge-install \
+            --packages-skip alpha_mapping \
+            --cmake-args -DCMAKE_BUILD_TYPE=Release
       - name: Validate configs (jsonschema)
         shell: bash
         run: |
           # Run config schema validation from repo root
           python3 scripts/validate_configs.py
-      - name: Test (all packages)
+      - name: Test (core packages)
         shell: bash
         run: |
           set -euo pipefail
@@ -164,3 +177,63 @@ jobs:
             alpha_ws/src/alpha_comms/test \
             alpha_ws/src/alpha_calibration_tools/test \
             -q
+
+  mapping-build:
+    name: ROS 2 Build (Humble) — mapping (non-gating)
+    needs: changes
+    if: ${{ needs.changes.outputs.mapping == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    env:
+      ALPHA_WS: alpha_ws
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup ROS 2 apt sources
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: humble
+      - name: Install base build tools (mapping)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ros-humble-ros-base \
+            ros-humble-pluginlib \
+            ros-humble-rclcpp \
+            ros-humble-sensor-msgs \
+            ros-humble-std-msgs \
+            python3-colcon-common-extensions \
+            python3-colcon-ros \
+            ros-dev-tools \
+            build-essential \
+            cmake \
+            python3-setuptools \
+            python3-pip \
+            python3-wheel \
+            python3-rosdep \
+            libyaml-cpp-dev \
+            libcurl4-openssl-dev \
+            python3-pytest \
+            ros-humble-std-srvs \
+            ros-humble-diagnostic-msgs
+          python3 -m pip install --user --upgrade pip
+          python3 -m pip install --user pyyaml jsonschema pytest
+      - name: Resolve mapping deps (rosdep)
+        run: |
+          sudo rosdep init || true
+          rosdep update || true
+          rosdep install --rosdistro humble --from-paths "$ALPHA_WS/src/alpha_mapping" -i -y || true
+      - name: Build alpha_mapping only (Release)
+        run: |
+          set +u
+          source /opt/ros/humble/setup.bash
+          set -u
+          cd "$ALPHA_WS"
+          colcon build --merge-install \
+            --packages-select alpha_mapping \
+            --cmake-args -DCMAKE_BUILD_TYPE=Release 2>&1 | tee ../mapping-build.log
+      - name: Upload mapping build log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mapping-build-log
+          path: mapping-build.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             ros-humble-ros-base \
+            ros-humble-pluginlib \
+            ros-humble-rclpy \
+            ros-humble-rclcpp \
+            ros-humble-std-msgs \
+            ros-humble-sensor-msgs \
             python3-colcon-common-extensions \
             python3-colcon-ros \
             ros-dev-tools \

--- a/alpha_ws/src/alpha_mapping/CMakeLists.txt
+++ b/alpha_ws/src/alpha_mapping/CMakeLists.txt
@@ -11,7 +11,13 @@ add_executable(nvblox src/nvblox_dummy_node.cpp)
 ament_target_dependencies(nvblox rclcpp sensor_msgs)
 
 add_executable(mapping_node src/mapping_node.cpp)
-ament_target_dependencies(mapping_node rclcpp sensor_msgs alpha_utils)
+ament_target_dependencies(mapping_node rclcpp sensor_msgs alpha_utils pluginlib)
+# Ensure local public headers are visible to dependents and this target
+target_include_directories(mapping_node
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
 
 install(TARGETS nvblox
   DESTINATION lib/${PROJECT_NAME}
@@ -23,6 +29,11 @@ install(TARGETS mapping_node
 
 add_library(nvblox_provider SHARED src/nvblox_provider.cpp)
 ament_target_dependencies(nvblox_provider rclcpp sensor_msgs pluginlib)
+target_include_directories(nvblox_provider
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
 
 pluginlib_export_plugin_description_file(alpha_mapping plugin_description.xml)
 

--- a/alpha_ws/src/alpha_mapping/src/mapping_node.cpp
+++ b/alpha_ws/src/alpha_mapping/src/mapping_node.cpp
@@ -133,12 +133,12 @@ public:
     std::string plugin_name = this->get_parameter("provider_plugin").as_string();
     try {
       loader_ = std::make_shared<pluginlib::ClassLoader<IMappingProvider>>("alpha_mapping", "alpha_mapping::IMappingProvider");
-      provider_.reset(loader_->createSharedInstance(plugin_name));
+      provider_ = loader_->createSharedInstance(plugin_name);
       provider_->configure(this);
       RCLCPP_INFO(this->get_logger(), "Loaded provider plugin: %s", plugin_name.c_str());
     } catch (const std::exception &e) {
       RCLCPP_WARN(this->get_logger(), "Failed to load provider plugin '%s': %s. Using DummyProvider.", plugin_name.c_str(), e.what());
-      provider_.reset(new DummyProvider());
+      provider_ = std::make_shared<DummyProvider>();
       provider_->configure(this);
     }
 
@@ -178,7 +178,7 @@ public:
   }
 
 private:
-  std::unique_ptr<IMappingProvider> provider_;
+  std::shared_ptr<IMappingProvider> provider_;
   std::vector<rclcpp::Subscription<PointCloud2>::SharedPtr> subs_;
   std::shared_ptr<pluginlib::ClassLoader<IMappingProvider>> loader_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr status_pub_;


### PR DESCRIPTION
- Core Build: build/test full workspace skipping alpha_mapping to unblock trunk.\n- Mapping Build: separate job runs on mapping changes and nightly; continue-on-error with log artifact.\n- Adds concurrency to cancel superseded runs and nightly schedule trigger.\n- Re-gate rule: after 7 consecutive green mapping builds (PR/nightly) or 1 week green, restore mapping into Core Build and drop the separate job.