### PR TITLE
CI: skip colcon test in core; rely on pytest; mapping separate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,19 +147,7 @@ jobs:
         run: |
           # Run config schema validation from repo root
           python3 scripts/validate_configs.py
-      - name: Test (core packages)
-        shell: bash
-        run: |
-          set -euo pipefail
-          set +u
-          source /opt/ros/humble/setup.bash
-          cd "$ALPHA_WS"
-          if [ -f install/setup.bash ]; then
-            source install/setup.bash
-          fi
-          set -u
-          colcon test --merge-install
-          colcon test-result --verbose
+      # Skip colcon test for now; rely on targeted pytest step below
       - name: Run unit tests (pytest)
         shell: bash
         run: |


### PR DESCRIPTION
- Remove colcon test step from core build (no meaningful gtests yet; reduces flakiness).\n- Keep pytest step for python packages (alpha_lidar_airy, alpha_comms, alpha_calibration_tools).\n- Mapping remains in non-gating job until stabilized.