### PR TITLE
CI: Test Policy v1.0 — unit-only gating; integration non-gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       mapping: ${{ steps.filter.outputs.mapping }}
+      tests: ${{ steps.filter.outputs.tests }}
     steps:
       - uses: actions/checkout@v4
       - id: filter
@@ -37,6 +38,8 @@ jobs:
             mapping:
               - 'alpha_ws/src/alpha_mapping/**'
               - 'alpha_ws/src/**/alpha_mapping*'
+            tests:
+              - 'alpha_ws/src/**/test/**'
 
   docs:
     name: Docs Validation
@@ -148,23 +151,17 @@ jobs:
           # Run config schema validation from repo root
           python3 scripts/validate_configs.py
       # Skip colcon test for now; rely on targeted pytest step below
-      - name: Run unit tests (pytest)
+      - name: Unit tests (gating)
         shell: bash
         run: |
           set -euo pipefail
           # Source ROS 2 and the built workspace so generated Python interfaces are importable
           set +u
           source /opt/ros/humble/setup.bash
-          if [ -f alpha_ws/install/setup.bash ]; then
-            source alpha_ws/install/setup.bash
-          fi
+          [ -f alpha_ws/install/setup.bash ] && source alpha_ws/install/setup.bash
           set -u
           # Run package unit tests directly with pytest
-          python3 -m pytest \
-            alpha_ws/src/alpha_lidar_airy/test \
-            alpha_ws/src/alpha_comms/test \
-            alpha_ws/src/alpha_calibration_tools/test \
-            -q
+          python3 -m pytest -m unit -q
 
   mapping-build:
     name: ROS 2 Build (Humble) — mapping (non-gating)
@@ -224,4 +221,64 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mapping-build-log
-          path: mapping-build.log
+      path: mapping-build.log
+
+  integration-tests:
+    name: Integration tests (non-gating)
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    env:
+      ALPHA_WS: alpha_ws
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup ROS 2 apt sources
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: humble
+      - name: Install base build tools (integration)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ros-humble-ros-base \
+            ros-humble-pluginlib \
+            ros-humble-rclpy \
+            ros-humble-rclcpp \
+            ros-humble-std-msgs \
+            ros-humble-sensor-msgs \
+            python3-colcon-common-extensions \
+            python3-colcon-ros \
+            ros-dev-tools \
+            build-essential \
+            cmake \
+            python3-setuptools \
+            python3-pip \
+            python3-wheel \
+            python3-rosdep \
+            libyaml-cpp-dev \
+            libcurl4-openssl-dev \
+            python3-pytest \
+            ros-humble-std-srvs \
+            ros-humble-diagnostic-msgs
+          python3 -m pip install --user --upgrade pip
+          python3 -m pip install --user pyyaml jsonschema pytest
+      - name: Resolve deps (workspace)
+        run: |
+          sudo rosdep init || true
+          rosdep update || true
+          rosdep install --rosdistro humble --from-paths "$ALPHA_WS/src" -i -y || true
+      - name: Build (Release, merge-install)
+        run: |
+          set +u
+          source /opt/ros/humble/setup.bash
+          set -u
+          cd "$ALPHA_WS"
+          colcon build --merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+      - name: Run integration tests (pytest -m integration)
+        run: |
+          set +u
+          source /opt/ros/humble/setup.bash
+          source alpha_ws/install/setup.bash
+          set -u
+          python3 -m pytest -m integration -q || true

--- a/alpha_ws/src/alpha_calibration_tools/test/test_tf_ok.py
+++ b/alpha_ws/src/alpha_calibration_tools/test/test_tf_ok.py
@@ -1,3 +1,4 @@
+import pytest
 import rclpy
 from std_srvs.srv import Trigger
 
@@ -10,6 +11,7 @@ def write_yaml(path, content):
         yaml.safe_dump(content, f)
 
 
+@pytest.mark.unit
 def test_tf_ok_enforce(tmp_path):
     # Create nominal/current within bounds
     nominal = {
@@ -52,4 +54,3 @@ def test_tf_ok_enforce(tmp_path):
         assert resp.success
     finally:
         rclpy.shutdown()
-

--- a/alpha_ws/src/alpha_comms/test/test_degrade_manager.py
+++ b/alpha_ws/src/alpha_comms/test/test_degrade_manager.py
@@ -1,5 +1,6 @@
 import time
 
+import pytest
 import rclpy
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
 
@@ -14,6 +15,7 @@ def make_breach_array():
     return arr
 
 
+@pytest.mark.unit
 def test_escalate_and_deescalate():
     rclpy.init()
     try:
@@ -33,4 +35,3 @@ def test_escalate_and_deescalate():
         assert node.current_level == 'L1'
     finally:
         rclpy.shutdown()
-

--- a/alpha_ws/src/alpha_lidar_airy/test/test_reorder.py
+++ b/alpha_ws/src/alpha_lidar_airy/test/test_reorder.py
@@ -1,6 +1,7 @@
 import math
 import struct
 from pathlib import Path
+import pytest
 
 import rclpy
 from sensor_msgs.msg import PointCloud2, PointField
@@ -50,6 +51,7 @@ def read_row_x_values(msg: PointCloud2):
     return xs
 
 
+@pytest.mark.unit
 def test_angle_table_parser_header_csv(tmp_path: Path):
     csv = tmp_path / 'angles.csv'
     csv.write_text('Channel,Vertical_Angle_deg\n1,10\n2,0\n3,20\n')
@@ -57,6 +59,7 @@ def test_angle_table_parser_header_csv(tmp_path: Path):
     assert vals == [10.0, 0.0, 20.0]
 
 
+@pytest.mark.unit
 def test_reorder_and_range_gate(tmp_path: Path):
     # Prepare CSV and YAML config
     csv = tmp_path / 'angles.csv'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts = -ra
+markers =
+    unit: hermetic tests (no ROS graph spin, no devices, deterministic)
+    integration: requires ROS graph, device stubs, timing, or orchestration
+xfail_strict = true
+


### PR DESCRIPTION
- Core Build: run only @pytest.mark.unit tests (gating).\n- Add non-gating integration-tests job (pytest -m integration) on changes and nightly.\n- Keep mapping in separate non-gating job.\n- Add pytest.ini with unit/integration markers; mark existing unit tests accordingly.\n- Re-gate mapping and integration after 7 consecutive green runs or 1 week green.