### PR TITLE
CI: fix artifact upload indentation (mapping-build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mapping-build-log
-      path: mapping-build.log
+          path: mapping-build.log
 
   integration-tests:
     name: Integration tests (non-gating)


### PR DESCRIPTION
Corrects indentation for 'path' under actions/upload-artifact in mapping-build job. Prevents workflow syntax error.