### PR TITLE
Tests: enable range_gate in reorder unit test

### DIFF
--- a/alpha_ws/src/alpha_lidar_airy/test/test_reorder.py
+++ b/alpha_ws/src/alpha_lidar_airy/test/test_reorder.py
@@ -79,6 +79,7 @@ def test_reorder_and_range_gate(tmp_path: Path):
     rclpy.init(args=[
         '--ros-args',
         '-p', f'config:={str(yaml)}',
+        '-p', 'range_gate_enabled:=true',
         '-p', 'strict:=true',
         '-p', 'input_front_topic:=/ignore',
         '-p', 'input_rear_topic:=/ignore',


### PR DESCRIPTION
Unit test expected NaN gating for out-of-range points, but range_gate is disabled by default. Pass range_gate_enabled:=true in test to make expectation match behavior.