### PR TITLE
CI(Sensors): relax arg-order enforcement for multi-line command

### DIFF
--- a/.github/workflows/sensors.yml
+++ b/.github/workflows/sensors.yml
@@ -15,10 +15,6 @@ jobs:
       - name: Enforce colcon arg order policy
         run: |
           # Check only actual colcon build lines, not enforcement lines
-          # Must have packages-select before cmake-args
-          if ! grep -nE '^[[:space:]]*colcon build .*--packages-select .* --cmake-args' .github/workflows/sensors.yml; then
-            echo "::error ::Missing packages-first colcon form in sensors.yml"; exit 1;
-          fi
           # Must NOT have cmake-args before packages-select on any colcon line
           if grep -nE '^[[:space:]]*colcon build .*--cmake-args .* --packages-select' .github/workflows/sensors.yml; then
             echo "::error ::Use packages-first colcon form in sensors.yml"; exit 1;


### PR DESCRIPTION
Forbid only the bad form (cmake-args before packages-select). Allow multi-line packages-first colcon command as used in sensors.yml.