### PR TITLE
CI: finalize Test Policy v1.0; cache & marker enforcement; keep mapping/integration non-gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
             ccache-${{ runner.os }}-
       - name: Configure ccache
         run: |
+          mkdir -p ~/.ccache
           echo 'max_size = 2G' > ~/.ccache/ccache.conf
       - name: Resolve ROS package deps (rosdep)
         shell: bash
@@ -268,6 +269,7 @@ jobs:
             ccache-${{ runner.os }}-
       - name: Configure ccache
         run: |
+          mkdir -p ~/.ccache
           echo 'max_size = 2G' > ~/.ccache/ccache.conf
       - name: Resolve mapping deps (rosdep)
         run: |
@@ -356,6 +358,7 @@ jobs:
             ccache-${{ runner.os }}-
       - name: Configure ccache
         run: |
+          mkdir -p ~/.ccache
           echo 'max_size = 2G' > ~/.ccache/ccache.conf
       - name: Resolve deps (workspace)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,38 @@ jobs:
       PKG_TARGET: ""
     steps:
       - uses: actions/checkout@v4
+      - name: Enforce test markers (unit/integration)
+        run: |
+          python3 - <<'PY'
+          import glob, sys
+          bad=[]
+          for f in glob.glob('alpha_ws/src/**/test/test_*.py', recursive=True):
+              s=open(f,'r',encoding='utf-8').read()
+              if '@pytest.mark.unit' not in s and '@pytest.mark.integration' not in s:
+                  bad.append(f)
+          if bad:
+              print("Tests missing @pytest.mark.unit or @pytest.mark.integration:")
+              print(*("- "+b for b in bad), sep="\n")
+              sys.exit(1)
+          PY
       - name: Setup ROS 2 apt sources
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: humble
+      - name: Configure apt
+        run: |
+          echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+          echo 'APT::Get::Assume-Yes "true";' | sudo tee /etc/apt/apt.conf.d/90-assume-yes
+          sudo apt-get update
+      - name: Cache rosdep metadata
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.ros/rosdep/sources.cache
+            ~/.ros/rosdep/sources.list.d
+          key: rosdep-${{ runner.os }}-${{ hashFiles('**/package.xml') }}
+          restore-keys: |
+            rosdep-${{ runner.os }}-
       - name: Install base build tools
         run: |
           sudo apt-get update
@@ -98,6 +126,18 @@ jobs:
             ros-humble-diagnostic-msgs
           python3 -m pip install --user --upgrade pip
           python3 -m pip install --user pyyaml jsonschema pytest
+      - name: Install ccache
+        run: sudo apt-get install -y ccache
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt','**/*.cmake','**/package.xml') }}
+          restore-keys: |
+            ccache-${{ runner.os }}-
+      - name: Configure ccache
+        run: |
+          echo 'max_size = 2G' > ~/.ccache/ccache.conf
       - name: Resolve ROS package deps (rosdep)
         shell: bash
         run: |
@@ -144,7 +184,8 @@ jobs:
           cd "$ALPHA_WS"
           colcon build --merge-install \
             --packages-skip alpha_mapping \
-            --cmake-args -DCMAKE_BUILD_TYPE=Release
+            --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                         -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Validate configs (jsonschema)
         shell: bash
         run: |
@@ -177,6 +218,20 @@ jobs:
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: humble
+      - name: Configure apt
+        run: |
+          echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+          echo 'APT::Get::Assume-Yes "true";' | sudo tee /etc/apt/apt.conf.d/90-assume-yes
+          sudo apt-get update
+      - name: Cache rosdep metadata
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.ros/rosdep/sources.cache
+            ~/.ros/rosdep/sources.list.d
+          key: rosdep-${{ runner.os }}-${{ hashFiles('**/package.xml') }}
+          restore-keys: |
+            rosdep-${{ runner.os }}-
       - name: Install base build tools (mapping)
         run: |
           sudo apt-get update
@@ -202,6 +257,18 @@ jobs:
             ros-humble-diagnostic-msgs
           python3 -m pip install --user --upgrade pip
           python3 -m pip install --user pyyaml jsonschema pytest
+      - name: Install ccache
+        run: sudo apt-get install -y ccache
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt','**/*.cmake','**/package.xml') }}
+          restore-keys: |
+            ccache-${{ runner.os }}-
+      - name: Configure ccache
+        run: |
+          echo 'max_size = 2G' > ~/.ccache/ccache.conf
       - name: Resolve mapping deps (rosdep)
         run: |
           sudo rosdep init || true
@@ -215,7 +282,8 @@ jobs:
           cd "$ALPHA_WS"
           colcon build --merge-install \
             --packages-select alpha_mapping \
-            --cmake-args -DCMAKE_BUILD_TYPE=Release 2>&1 | tee ../mapping-build.log
+            --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                         -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache 2>&1 | tee ../mapping-build.log
       - name: Upload mapping build log
         if: always()
         uses: actions/upload-artifact@v4
@@ -237,6 +305,20 @@ jobs:
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: humble
+      - name: Configure apt
+        run: |
+          echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+          echo 'APT::Get::Assume-Yes "true";' | sudo tee /etc/apt/apt.conf.d/90-assume-yes
+          sudo apt-get update
+      - name: Cache rosdep metadata
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.ros/rosdep/sources.cache
+            ~/.ros/rosdep/sources.list.d
+          key: rosdep-${{ runner.os }}-${{ hashFiles('**/package.xml') }}
+          restore-keys: |
+            rosdep-${{ runner.os }}-
       - name: Install base build tools (integration)
         run: |
           sudo apt-get update
@@ -263,6 +345,18 @@ jobs:
             ros-humble-diagnostic-msgs
           python3 -m pip install --user --upgrade pip
           python3 -m pip install --user pyyaml jsonschema pytest
+      - name: Install ccache
+        run: sudo apt-get install -y ccache
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt','**/*.cmake','**/package.xml') }}
+          restore-keys: |
+            ccache-${{ runner.os }}-
+      - name: Configure ccache
+        run: |
+          echo 'max_size = 2G' > ~/.ccache/ccache.conf
       - name: Resolve deps (workspace)
         run: |
           sudo rosdep init || true
@@ -274,7 +368,8 @@ jobs:
           source /opt/ros/humble/setup.bash
           set -u
           cd "$ALPHA_WS"
-          colcon build --merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+          colcon build --merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                       -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Run integration tests (pytest -m integration)
         run: |
           set +u

--- a/.github/workflows/sensors.yml
+++ b/.github/workflows/sensors.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           # Check only actual colcon build lines, not enforcement lines
           # Must NOT have cmake-args before packages-select on any colcon line
-          if grep -nE '^[[:space:]]*colcon build .*--cmake-args .* --packages-select' .github/workflows/sensors.yml; then
+          if grep -nE '^[[:space:]]*colcon build[[:space:]].*--cmake-args[[:space:]].* --packages-select' .github/workflows/sensors.yml; then
             echo "::error ::Use packages-first colcon form in sensors.yml"; exit 1;
           fi
       - name: Setup ROS 2 apt sources

--- a/.github/workflows/sensors.yml
+++ b/.github/workflows/sensors.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            ros-humble-ros-base \
             build-essential cmake \
             libyaml-cpp-dev \
             ros-humble-rclcpp \
@@ -51,6 +52,9 @@ jobs:
       - name: Build third-party (smoke)
         run: |
           set -e
+          set +u
+          source /opt/ros/humble/setup.bash
+          set -u
           cd alpha_ws
           colcon build --event-handlers console_cohesion+ --packages-up-to rslidar_sdk rslidar_msg || true
       - name: Resolve core workspace deps (smoke)
@@ -59,6 +63,9 @@ jobs:
       - name: Build core LiDAR packages (smoke)
         run: |
           set -e
+          set +u
+          source /opt/ros/humble/setup.bash
+          set -u
           cd alpha_ws
           colcon build --event-handlers console_cohesion+ \
             --packages-up-to alpha_lidar_airy_cpp alpha_lidar_airy alpha_bringup alpha_testing \

--- a/.github/workflows/sensors.yml
+++ b/.github/workflows/sensors.yml
@@ -61,5 +61,5 @@ jobs:
           set -e
           cd alpha_ws
           colcon build --event-handlers console_cohesion+ \
-            --packages-select alpha_lidar_airy_cpp alpha_lidar_airy alpha_bringup alpha_testing \
+            --packages-up-to alpha_lidar_airy_cpp alpha_lidar_airy alpha_bringup alpha_testing \
             --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON


### PR DESCRIPTION
Lock in Test Policy v1.0 and stabilize CI signal while keeping trunk green.

Summary
- Core gating: build full workspace excluding `alpha_mapping`; run only unit tests (`pytest -m unit`).
- Non‑gating:
  - Mapping Build: builds `alpha_mapping` on changes + nightly, uploads logs, `continue-on-error: true`.
  - Integration Tests: `pytest -m integration` on changes + nightly, `continue-on-error: true`.
- Promotion rule (policy): after 7 consecutive green mapping + integration runs (PRs/nightly) or 1 week green, re‑gate them.
- Sensors enforcement: keep relaxed policy — forbid only bad form (`--cmake-args` before `--packages-select`), allow multiline packages‑first.

What changed
- Added apt hardening and caching to Core, Mapping, and Integration jobs:
  - Configure apt retries + noninteractive.
  - Cache rosdep metadata via `actions/cache@v4`.
  - Install/configure/cache `ccache`.
  - Wire ccache into all `colcon build` invocations.
- Added “Enforce test markers” step in Core to require `@pytest.mark.unit` or `@pytest.mark.integration` on all tests.
- Kept unit‑only pytest step as the gating test execution; no `colcon test`.
- Preserved `set +u`/`set -u` around `source` to avoid `nounset` issues.
- Maintained concurrency and non‑gating behavior for mapping/integration.

Files
- .github/workflows/ci.yml
- .github/workflows/sensors.yml

Expected outcome
- Fast, stable Core CI with deterministic unit‑only gating.
- Continued non‑gating visibility for mapping/integration with artifacts.
- Fewer spurious CI failures due to apt/rosdep/network variability.

Follow‑up
- After a week of green mapping/integration (or 7 consecutive runs), open a PR to promote them back into gating per policy.
