### PR TITLE
LiDAR: honor YAML range_m for unit range-gate

### DIFF
--- a/alpha_ws/src/alpha_lidar_airy/alpha_lidar_airy/reorder_node.py
+++ b/alpha_ws/src/alpha_lidar_airy/alpha_lidar_airy/reorder_node.py
@@ -123,6 +123,16 @@ class AiryReorderNode(Node):
         self._expected_w = int(cfg.get('expected_dims', {}).get('width', 900))
         self._range_min = float(self.get_parameter('range_min_m').get_parameter_value().double_value)
         self._range_max = float(self.get_parameter('range_max_m').get_parameter_value().double_value)
+        # Allow YAML to override range gate bounds if provided
+        try:
+            rg = cfg.get('range_m', {}) if isinstance(cfg, dict) else {}
+            if isinstance(rg, dict):
+                if rg.get('min') is not None:
+                    self._range_min = float(rg['min'])
+                if rg.get('max') is not None:
+                    self._range_max = float(rg['max'])
+        except Exception:
+            pass
         self._range_gate_enabled = bool(self.get_parameter('range_gate_enabled').get_parameter_value().bool_value)
         self._timestamp_policy = (self.get_parameter('timestamp_policy').get_parameter_value().string_value or 'sensor').lower()
         self._backend = (self.get_parameter('backend').get_parameter_value().string_value or 'numpy').lower()


### PR DESCRIPTION
Fix failing unit test by reading range_m {min,max} from the YAML config in AiryReorderNode.\n\nDetails\n- Keep ROS params range_min_m/range_max_m as defaults.\n- If YAML provides range_m.min/max, override bounds accordingly.\n- range_gate_enabled remains param-driven.\n\nThis makes the unit test hermetic: it sets range_gate_enabled via param and supplies bounds via YAML file.